### PR TITLE
Print message for tests if instruction limit exceeded.

### DIFF
--- a/src/test/tests/cs061/assn2.cpp
+++ b/src/test/tests/cs061/assn2.cpp
@@ -23,6 +23,7 @@ void shutdown() {
 
 static const std::string error_prefix = "Failed: Program I/O differs from expected I/O: \\n\\\"";
 static const std::string error_conjunction = "\\\", should be: \\n\\\"";
+static const std::string error_instruction_limit = "Failed: Program exceeded instruction limit!";
 
 std::string BuildErrorLabel(const std::string &expected, const std::string &got) {
     return  error_prefix + got + error_conjunction + expected + "\\\"";
@@ -56,7 +57,12 @@ void ExecuteTest(lc3::sim &sol_sim, lc3::sim &sim, Tester &tester, double total_
     std::string output = ReplaceNewLines(tester.getOutput());
     ReplaceUnprintables(output);
 
-    std::string label = BuildErrorLabel(solution, output); 
+    std::string label = BuildErrorLabel(solution, output);
+
+    if (sim.didExceedInstLimit()) {
+        label = error_instruction_limit;
+    }
+
     tester.verify(label, success && tester.checkContain(tester.getOutput(), tester.getSolutionOutput()), total_points);    
 }
 

--- a/src/test/tests/cs061/assn3.cpp
+++ b/src/test/tests/cs061/assn3.cpp
@@ -22,6 +22,7 @@ void shutdown() {
 
 static const std::string error_prefix = "Failed: Program I/O differs from expected I/O: \\n\\\"";
 static const std::string error_conjunction = "\\\", should be: \\n\\\"";
+static const std::string error_instruction_limit = "Failed: Program exceeded instruction limit!";
 
 std::string BuildErrorLabel(const std::string &expected, const std::string &got) {
     return  error_prefix + got + error_conjunction + expected + "\\\"";
@@ -53,6 +54,11 @@ void ExecuteTest(lc3::sim &sol_sim, lc3::sim &sim, Tester &tester, double total_
     std::string label = BuildErrorLabel(tester.getSolutionOutput(), tester.getOutput()); 
     ReplaceNewLines(label);
     ReplaceUnprintables(label);
+
+    if (sim.didExceedInstLimit()) {
+        label = error_instruction_limit;
+    }
+
     tester.verify(label, success && tester.checkContain(tester.getOutput(), tester.getSolutionOutput()), total_points);    
 }
 

--- a/src/test/tests/cs061/assn4.cpp
+++ b/src/test/tests/cs061/assn4.cpp
@@ -22,6 +22,7 @@ void shutdown() {
 
 static const std::string error_prefix = "Failed: Program I/O differs from expected I/O: \\n\\\"";
 static const std::string error_conjunction = "\\\", should be: \\n\\\"";
+static const std::string error_instruction_limit = "Failed: Program exceeded instruction limit!";
 
 std::string BuildErrorLabel(const std::string &expected, const std::string &got) {
     return  error_prefix + got + error_conjunction + expected;
@@ -45,6 +46,11 @@ void ExecuteTest(lc3::sim &sol_sim, lc3::sim &sim, Tester &tester, double total_
     success &= sol_sim.runUntilHalt();
 
     std::string label = "Failed: Program register output differs from the solution register output."; 
+
+    if (sim.didExceedInstLimit()) {
+        label = error_instruction_limit;
+    }
+
     tester.verify(label, success && sim.readReg(reg) == sol_sim.readReg(reg), total_points);    
 }
 

--- a/src/test/tests/cs061/assn5.cpp
+++ b/src/test/tests/cs061/assn5.cpp
@@ -22,6 +22,7 @@ void shutdown() {
 
 static const std::string error_prefix = "Failed: Program I/O differs from expected I/O: \\n\\\"";
 static const std::string error_conjunction = "\\\", should be: \\n\\\"";
+static const std::string error_instruction_limit = "Failed: Program exceeded instruction limit!";
 
 bool not_printable(char c) {
     return !isprint(c) && !isspace(c);
@@ -59,6 +60,11 @@ void ExecuteTest(lc3::sim &sol_sim, lc3::sim &sim, Tester &tester, double total_
     std::string label = BuildErrorLabel(tester.getSolutionOutput(), tester.getOutput()); 
     ReplaceNewLines(label);
     ReplaceUnprintables(label);
+
+    if (sim.didExceedInstLimit()) {
+        label = error_instruction_limit;
+    }
+
     tester.verify(label, success && tester.checkContain(tester.getOutput(), tester.getSolutionOutput()), total_points);    
 }
 


### PR DESCRIPTION
This PR explicitly sets the failure message when test cases (assignment 2 through 5) fail due to exceeding the set instruction limit. The message displayed is "Failure: Program exceeded the instruction limit".